### PR TITLE
`[DEV][FIX]` fixed image tag unique constrain

### DIFF
--- a/src/modules/tag/domain/repositories/Tag.repository.ts
+++ b/src/modules/tag/domain/repositories/Tag.repository.ts
@@ -29,4 +29,6 @@ export interface TagRepositoryInterface {
     createImageTag(data: CreateImageTagDTO): Promise<CreateImageTagResponseDTO>;
     deleteImageTag(data: DeleteImageTagDTO): Promise<DeleteImageTagResponseDTO>;
     findTagsByImageId(data: FindTagsByImageIdDTO): Promise<FindTagsByImageIdResponseDTO[]>;
+    findInactiveImageTag(data: { image_id: number; tag_id: number }): Promise<any | null>;
+    reactivateImageTag(data: { image_id: number; tag_id: number; updated_by: number }): Promise<any>;
 } 

--- a/src/modules/tag/infra/db/repositories/Tag.repository.ts
+++ b/src/modules/tag/infra/db/repositories/Tag.repository.ts
@@ -115,7 +115,7 @@ export class TagRepository implements TagRepositoryInterface {
                 },
             },
             data: {
-                status: 'DELETED',
+                status: 'INACTIVE',
                 updated_by: data.updated_by,
             },
         });
@@ -135,6 +135,35 @@ export class TagRepository implements TagRepositoryInterface {
         });
 
         return imageTags.map((imageTag) => imageTag.tag);
+    }
+
+    async findInactiveImageTag(data: { image_id: number; tag_id: number }): Promise<any | null> {
+        const imageTag = await this.prisma.imageTag.findFirst({
+            where: {
+                image_id: data.image_id,
+                tag_id: data.tag_id,
+                status: 'INACTIVE',
+            },
+        });
+
+        return imageTag;
+    }
+
+    async reactivateImageTag(data: { image_id: number; tag_id: number; updated_by: number }): Promise<any> {
+        const imageTag = await this.prisma.imageTag.update({
+            where: {
+                image_id_tag_id: {
+                    image_id: data.image_id,
+                    tag_id: data.tag_id,
+                },
+            },
+            data: {
+                status: 'ACTIVE',
+                updated_by: data.updated_by,
+            },
+        });
+
+        return imageTag;
     }
 
     async findAll(): Promise<FindAllTagsResponseDTO[]> {


### PR DESCRIPTION
## Descrição

foi resolvido um problema que acontecia quando uma imagem era atualizada com uma tag que ja fez parte daquela imagem alguma vez, o back-end tentava recriar a associação entre a imagem e a tag ao invés de reativar a associação que ja existia.